### PR TITLE
Add Script to Recursively Add Directories to PATH in Zsh

### DIFF
--- a/.files/.bin/experimental/add_to_path_permanent.sh
+++ b/.files/.bin/experimental/add_to_path_permanent.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+################################################################################
+# Script: add_to_path_permanent.sh
+# Autor: Roberto Flores
+# Correo: fq211776@alumno.udb.edu.sv
+# GitHub: Elixir-Software-Developer
+# Versión: 1.0
+# Descripción: Script para agregar directorios al PATH de forma recursiva y 
+#              permanente en Zsh.
+################################################################################
+
 # Función para agregar carpetas al PATH de forma recursiva
 add_to_path_recursive() {
     local dir="$1"

--- a/.files/.bin/experimental/add_to_path_permanent.sh
+++ b/.files/.bin/experimental/add_to_path_permanent.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Función para agregar carpetas al PATH de forma recursiva
+add_to_path_recursive() {
+    local dir="$1"
+    local depth="$2"
+
+    # Verificar si la carpeta existe
+    if [ -d "$dir" ]; then
+        # Verificar si la carpeta ya está en el PATH
+        if [[ ":$PATH:" != *":$dir:"* ]]; then
+            # Agregar la carpeta al PATH temporalmente
+            export PATH="$dir:$PATH"
+            echo "Agregada al PATH temporalmente: $dir"
+
+            # Verificar si la carpeta ya está en el archivo .zshrc
+            if ! grep -q "export PATH=\"$dir:\$PATH\"" ~/.zshrc; then
+                # Agregar la carpeta al PATH permanentemente
+                echo "export PATH=\"$dir:\$PATH\"" >> ~/.zshrc
+                echo "Agregada al PATH permanentemente: $dir"
+            else
+                echo "La carpeta ya está en el archivo .zshrc: $dir"
+            fi
+        else
+            echo "La carpeta ya está en el PATH: $dir"
+        fi
+
+        # Recorrer subcarpetas
+        for subdir in "$dir"/*; do
+            if [ -d "$subdir" ]; then
+                add_to_path_recursive "$subdir" "$((depth + 1))"
+            fi
+        done
+    fi
+}
+
+# Carpeta raíz desde la cual comenzar la búsqueda recursiva
+root_dir="$1"
+
+# Verificar si se proporcionó una carpeta raíz
+if [ -z "$root_dir" ]; then
+    echo "Uso: $0 <carpeta_raíz>"
+    exit 1
+fi
+
+# Llamar a la función recursiva
+add_to_path_recursive "$root_dir" 0
+
+# Recargar el archivo de configuración del shell para aplicar los cambios inmediatamente
+source ~/.zshrc


### PR DESCRIPTION
This pull request introduces a new Bash script that recursively adds directories to the `PATH` in Zsh, ensuring that the changes are permanent and avoiding duplication of paths.

### Script Added:

- **`add_to_path_permanent.sh`**
  - This script recursively adds directories to the `PATH` in Zsh. It checks if a directory is already in the `PATH` and avoids adding it again to prevent duplication. Additionally, it ensures that the changes are permanent by adding the directories to the `.zshrc` file.

### Purpose:

- **Easier PATH Management**: By using this script, it becomes easier to manage and update the `PATH` environment variable, especially when dealing with multiple directories and subdirectories.
- **Avoid Duplication**: The script checks if a directory is already in the `PATH` and in the `.zshrc` file before adding it, preventing duplication and ensuring a clean and efficient `PATH`.
- **Permanent Changes**: The script makes the changes permanent by adding the directories to the `.zshrc` file, ensuring that the `PATH` is updated every time a new shell session is started.

### Testing:

- The script has been tested on multiple systems to ensure compatibility and functionality.
- All paths have been verified to be added correctly without duplication.

### Screenshots:
![image](https://github.com/user-attachments/assets/375c5d22-68d2-4215-b63e-d6ce38bc966d)


Thank you for reviewing this pull request. Your feedback is greatly appreciated!